### PR TITLE
#FEBRABANSD-311 - Corrige o atributo de representação de expressão regular.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * Remove a definição de tamanho de máximo e expressão regular no atributo `name` de `priorityServices` em contas PN na especificação Open API, pois se trata de uma enumeração.
 * Adiciona a definição de expressão regular no atributo `name` de `otherServices` em contas PN na especificação Open API, conforme dicionário de dados.
+* Corrige o atributo de representação de expressão regular para os atributos de `serviceBundleDetail` em contas PN/PJ na especificação Open API (estava como format porém o utilizado é pattern).
 
 # 2.0.0
 [30/11/2020]

--- a/documentation/source/swagger/swagger_products_services_apis.yaml
+++ b/documentation/source/swagger/swagger_products_services_apis.yaml
@@ -540,14 +540,14 @@ components:
         code:
           type: string
           maxLength: 100
-          format: \w*\W*
+          pattern: \w*\W*
           description: |
             Código que identifica o Serviço que compõe o Pacote de Serviços, podendo ser da lista de Serviços Prioritários ou Outros Serviços. p.ex. segundo Resolução 3.919 do Bacen: 'SAQUE_TERMINAL'.
           example: SAQUE_TERMINAL
         chargingTriggerInfo:
           type: string
           maxLength: 2000
-          format: \w*\W*
+          pattern: \w*\W*
           description: |
             Fatos geradores de cobrança que incidem sobre serviço que compõe o Pacote de Serviços.
           example: |
@@ -555,14 +555,14 @@ components:
         eventLimitQuantity:
           type: string
           maxLength: 6
-          format: ^(\d{1,6}){1}$
+          pattern: ^(\d{1,6}){1}$
           description: |
             Segundo Resolução  4196, BCB, de 2013: Quantidade de eventos previstos no Pacote de Serviços (Número de eventos incluídos no mês) p.ex.'2'. No caso de quantidade ilimitada, reportar 999999
           example: '2'
         freeEventQuantity:
           type: string
           maxLength: 6
-          format: ^(\d{1,6}){1}$
+          pattern: ^(\d{1,6}){1}$
           description: |
             Segundo Resolução  4196, BCB, de 2013: Quantidade de eventos previstos no Pacote de Serviços com isenção de Tarifa.p.ex.'1'  No caso de quantidade ilimitada, reportar 999999
           example: '1'


### PR DESCRIPTION
Corrige o atributo de representação de expressão regular para os atributos de `serviceBundleDetail` em contas PN/PJ na especificação Open API (estava como format porém o utilizado é pattern).