### PR TITLE
Adiciona descrição complementar dos valores da enumeração `period` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # {version}
 [{date}]
 
+## Melhoria
+
+* Adiciona descrição complementar dos valores da enumeração `period` na especificação Open API de métricas.
+
 ## Correção
 
 * Remove a definição de tamanho de máximo e expressão regular no atributo `name` de `priorityServices` em contas PN na especificação Open API, pois se trata de uma enumeração.

--- a/documentation/source/includes/partials_admin_apis/_metrics.md.erb
+++ b/documentation/source/includes/partials_admin_apis/_metrics.md.erb
@@ -150,7 +150,7 @@ Este *endpoint* possibilita ao diretório consultar estatísticas operacionais d
 
 | Propriedade  | Código     | Definição                                 |
 |:------------ |:-----------|:------------------------------------------|
-| period       | CURRENT    | Métricas do dia atual.                     |
+| period       | CURRENT    | Métricas do dia atual.                    |
 | period       | ALL        | Métricas de todo o período disponível.    |
 
 ### Resposta

--- a/documentation/source/swagger/swagger_admin_apis.yaml
+++ b/documentation/source/swagger/swagger_admin_apis.yaml
@@ -26,7 +26,10 @@ paths:
               - CURRENT
               - ALL
           required: false
-          description: Período a ser consultado
+          description: |
+            Período a ser consultado
+              * `CURRENT` - Métricas do dia atual.
+              * `ALL` - Métricas de todo o período disponível.
       responses:
         '200':
           description: Dados das métricas


### PR DESCRIPTION
Adiciona descrição complementar dos valores da enumeração `period` na especificação Open API de métricas.