### PR TITLE
Corrigi o dicionário `personal_acounts.csv`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Correção
 
+* Corrigi o dicionário `personal_acounts.csv` onde a definição de `name` em `priorityServices` trazia um exemplo que não condiz com os valores da enumeração.
 * Remove a definição de tamanho de máximo e expressão regular no atributo `name` de `priorityServices` em contas PN na especificação Open API, pois se trata de uma enumeração.
 * Adiciona a definição de expressão regular no atributo `name` de `otherServices` em contas PN na especificação Open API, conforme dicionário de dados.
 * Corrige o atributo de representação de expressão regular para os seguintes atributos na especificação Open API (estavam como `format` porém o utilizado é `pattern`):

--- a/documentation/source/dictionary/personal_accounts.csv
+++ b/documentation/source/dictionary/personal_accounts.csv
@@ -18,7 +18,7 @@ CONTA_POUPANCA
 CONTA_PAGAMENTO_PRE_PAGA";1;1;NA;
 openBankingBrazil/<brand>/companies/personalAccounts/fees/;;Objeto que reúne informações de tarifas de serviços;objeto;;;;;;;;
 openBankingBrazil/<brand>/companies/personalAccounts/fees/priorityServices/;;Lista das Tarifas cobradas sobre Serviços Prioritários;Lista;;;;;1;31;;
-openBankingBrazil/<brand>/companies/personalAccounts/fees/priorityServices/name;name;Nome dos Serviços prioritários, segundo Resolução 3.919 do Bacen, para pessoa natural. p.ex. 'Fornecimento de extrato de um período de conta de depósitos à vista e de poupança';Texto;;Obrigatório;;"CONFECCAO_CADASTRO_INICIO_RELACIONAMENTO
+openBankingBrazil/<brand>/companies/personalAccounts/fees/priorityServices/name;name;Nome dos Serviços prioritários, segundo Resolução 3.919 do Bacen, para pessoa natural. (vide Enum);Texto;;Obrigatório;;"CONFECCAO_CADASTRO_INICIO_RELACIONAMENTO
 FORNECIMENTO_2_VIA_CARTAO_FUNCAO_DEBITO
 FORNECIMENTO_2_VIA_CARTAO_FUNCAO_MOVIMENTACAO_CONTA_POUPANCA
 EXCLUSAO_CADASTRO_EMITENTES_CHEQUES_SEM_FUNDO_CCF
@@ -52,7 +52,7 @@ ORDEM_PAGAMENTO
 
 
 ";1;1;NA;
-openBankingBrazil/<brand>/companies/personalAccounts/fees/priorityServices/code;code;Lista das Siglas de identificação do Serviço Prioritário, segundo Resolução 3.919 do Bacen. p. ex. 'ORDEM_PAGAMENTO';Texto;;Obrigatório;;"CADASTRO
+openBankingBrazil/<brand>/companies/personalAccounts/fees/priorityServices/code;code;Lista das Siglas de identificação do Serviço Prioritário, segundo Resolução 3.919 do Bacen. Vide Enum;Texto;;Obrigatório;;"CADASTRO
 2_VIA_CARTAO_DEBITO
 2_VIA_CARTAO_POUPANCA
 EXCLUSAO_CCF
@@ -169,4 +169,4 @@ openBankingBrazil/<brand>/companies/personalAccounts/termsConditions/minimumBala
 openBankingBrazil/<brand>/companies/personalAccounts/termsConditions/elegibilityCriteriaInfo;elegibilityCriteriaInfo;Critérios de qualificação do cliente com a finalidade de definir sua elegibilidade para a aquisição do tipo de conta. Campo Aberto;Texto;2000;Obrigatório;\w*\W*;;1;1;NA;
 openBankingBrazil/<brand>/companies/personalAccounts/termsConditions/closingProcessInfo;closingProcessInfo;Procedimentos de encerramento para o tipo de conta tratado. Possibilidade de inscrição da URL. Endereço eletrônico de acesso ao canal. p.ex. 'https://example.com/mobile-banking';Texto;2000;Obrigatório;\w*\W*;;1;1;NA;
 openBankingBrazil/<brand>/companies/personalAccounts/incomeRate/savingAccount;savingAccount;Descrição da Remuneração especificamente para Conta de Poupança. Deve ser preenchido com a determinação legal vigente. p.ex. '70% da Taxa Selic (6,5%) = 4,55%, que é o atual rendimento anual da poupança. O rendimento mensal é de 0,3715';Texto;2000;Condicional;\w*\W*;;0;1;De preenchimento obrigatório para CONTA_POUPANCA;
-openBankingBrazil/<brand>/companies/personalAccounts/incomeRate/prepaidPaymentAccount;prepaidPaymentAccount;Percentual em favor do titular da conta de pagamento pré-paga. Campo Livre;Texto;2000;Condicional;\w*\W*;;0;1;De preenchimento obrigatório para Conta do Tipo CONTA_PAGAMENTO_PRE_PAGA ;
+openBankingBrazil/<brand>/companies/personalAccounts/incomeRate/prepaidPaymentAccount;prepaidPaymentAccount;Campo Livre. Deve explicitar o Percentual em favor do titular da conta de pagamento pré-paga. P.ex. '40% de rendimento a.m.';Texto;2000;Condicional;\w*\W*;;0;1;De preenchimento obrigatório para Conta do Tipo CONTA_PAGAMENTO_PRE_PAGA ;


### PR DESCRIPTION
Corrigi o dicionário `personal_acounts.csv` onde a definição de `name`  em `priorityServices` trazia um exemplo que não condiz com os valores da enumeração.