### PR TITLE
Fix regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@
   - Todos os atributos `cnpjNumber` em Canais Telefônicos, Canais Eletrônicos, Correspondentes Bancários e Dependências Próprias
   - `countryCallingCode`, `areaCode`, `number` em Canais Telefônicos
   - `code`, `postCode` em Dependências Próprias
+* Remove indicador de "Não se Aplica" na expressão regular dos atributos opcionais e condicionais da API de Canais de Atendimento, conforme indicado no dicionário de dados:
+  - `relatedBranch` em Dependências Próprias
+  - `latitude` em Dependências Próprias
+  - `longitude` em Dependências Próprias
 * Corrigi o path da especificação Open API das APIs comuns de `outage` para `outages`.
 * Corrigi o pattern de `CNPJ` e descrição de `InterestRates` em adiantamento à Depositantes.
 * Corrigi obrigatoriedade e tamanho máximo na especificação Open API para os seguintes atributos:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,8 +56,9 @@
   - `code`, `postCode` em Dependências Próprias
 * Remove indicador de "Não se Aplica" na expressão regular dos atributos opcionais e condicionais da API de Canais de Atendimento, conforme indicado no dicionário de dados:
   - `relatedBranch` em Dependências Próprias
-  - `latitude` em Dependências Próprias
-  - `longitude` em Dependências Próprias
+  - `latitude`
+  - `longitude`
+  - `ibgeCode` 
 * Corrigi o path da especificação Open API das APIs comuns de `outage` para `outages`.
 * Corrigi o pattern de `CNPJ` e descrição de `InterestRates` em adiantamento à Depositantes.
 * Corrigi obrigatoriedade e tamanho máximo na especificação Open API para os seguintes atributos:

--- a/documentation/source/includes/partials_schemas/_response_phone_channels_list.md.erb
+++ b/documentation/source/includes/partials_schemas/_response_phone_channels_list.md.erb
@@ -56,7 +56,7 @@
 |:------------    |:---------------------------------                        |:-----------  |:----------------------------------------------------  |
 | data            | object                                                   | Sim          |                                                       |
 | brand           | [PhoneChannelsBrand](#schemaPhoneChannelsBrand)          | Sim          | Organização controladora do grupo de instituições financeiras.      |
-| links           | [[LinksPaginated](#schemaLinksPaginated)]                | Sim          |                                                       |
+| links           | [LinksPaginated](#schemaLinksPaginated)]                 | Sim          |                                                       |
 | meta            | [MetaPaginated](#schemaMetaPaginated)                    | Sim          |                                                       |
 
 ## PhoneChannelsBrand
@@ -101,7 +101,7 @@
 |     Nome     |  Tipo                                                              | Obrigatório  |                            Definição                                                                                                             |
 |:------------ |:---------------------------------                                  |:-----------  |:----------------------------------------------------                                                                                             |
 | name         | string                                                             | Sim          | Nome da Marca reportada pelo participante do Open Banking. O conceito a que se refere a 'marca' utilizada está em definição pelos participantes. |
-| companies    | [[PhoneChannelsCompanies](#schemaPhoneChannelsCompanies)]          | Sim          | Lista de instituições pertencentes à marca.                                                                                                      |
+| companies    | [PhoneChannelsCompanies](#schemaPhoneChannelsCompanies)            | Sim          | Lista de instituições pertencentes à marca.                                                                                                      |
 
 ## PhoneChannelsCompanies
 <a id="schemaPhoneChannelsCompanies"></a>
@@ -142,7 +142,7 @@
 | name                 | string                                  | Sim         | Nome da Instituição, pertencente à organização, responsável pelo Canal Telefônico. Ex. 'Empresa da Organização A'.                                   |
 | cnpjNumber           | string                                  | Sim         | CNPJ da instituição  responsável pelo canal de atendimento telefônico - o CNPJ corresponde ao número de inscrição no Cadastro de Pessoa Jurídica.    |
 | urlComplementaryList | string                                  | Não         | URL do link que conterá a lista complementar com os nomes e CNPJs agrupados sob o mesmo cnpjNumber.                                                  |
-| phoneChannels        | [[PhoneChannels](#schemaPhoneChannels)] | Sim         | Lista de canais de atendimento telefônico.                                                                                                                                                                                                                                                                                                                                                                                     |
+| phoneChannels        | [PhoneChannels](#schemaPhoneChannels)   | Sim         | Lista de canais de atendimento telefônico.                                                                                                                                                                                                                                                                                                                                                                                     |
 
 ## PhoneChannels
 <a id="schemaPhoneChannels"></a>
@@ -174,7 +174,7 @@
 |     Nome              |  Tipo                                                                       | Obrigatório |                            Definição                                                                                                                                                                                                                                          | Restrições                                                                               |
 |:------------          |:--------------------------------------------------------------------------- |:----------- |:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |:-----------------                                                                        |
 | identification        | [PhoneChannelsIdentification](#schemaPhoneChannelsIdentification)           | Sim         |                                                                                                                                                                                                                                                                               |                                                                                          |
-| services              | [[PhoneChannelsServices](#schemaPhoneChannelsServices)]                     | Sim         | Traz a relação de serviços disponbilizados pelo Canal de Atendimento                                                                                                                                                                                                          |                                                                                          |
+| services              | [PhoneChannelsServices](#schemaPhoneChannelsServices)                       | Sim         | Traz a relação de serviços disponbilizados pelo Canal de Atendimento                                                                                                                                                                                                          |                                                                                          |
 
 ## PhoneChannelsIdentification
 <a id="schemaPhoneChannelsIdentification"></a>
@@ -198,7 +198,7 @@
 |:------------    |:---------------------------------                       |:----------- |:--------------------------------------------------                                                                                 |:------------------------------------                                                                                        |
 | type            | [Enum PhoneChannelsType](#schemaPhoneChannelsType)      | Sim         | Tipo de canal telefônico de atendimento.                                                                                           | O Tipo de Canal determina o Tipo de Acesso a ele relacionado:  telefone da central, telefone do SAC, telefone da ouvidoria. |
 | additionalInfo  | string                                                  | Não         | Texto livre para complementar informação relativa ao Serviço disponível, quando for selecionada a opção 'OUTROS_PRODUTOS_SERVICOS' | Só será preenchido quando o tipo de canal de atendimento for Outros.                                                        |
-| phones          | [[PhoneChannelsPhones](#schemaPhoneChannelsPhones)]     | Não         | Telefones de contato com o canal de atendimento.                                                                                   |                                                                                                                             |
+| phones          | [PhoneChannelsPhones](#schemaPhoneChannelsPhones)       | Não         | Telefones de contato com o canal de atendimento.                                                                                   |                                                                                                                             |
 
 ### Enum PhoneChannelsType
 <a id="schemaPhoneChannelsType"></a>

--- a/documentation/source/includes/partials_schemas/_response_shared_automated_teller_machines_list.md.erb
+++ b/documentation/source/includes/partials_schemas/_response_shared_automated_teller_machines_list.md.erb
@@ -135,10 +135,10 @@
 
 ```
 
-|Nome     |Tipo                                                                                     |Obrigatório|Definição                                  |
-|:------- |:--------------------------------------------------------------------------------------- |:--------- |:----------------------------------------- |
-|name     |string                                                                                   |Não        |Nome da Marca selecionada pelas Organizações.|
-|companies|[[SharedAutomatedTellerMachinesCompanies](#schemaSharedAutomatedTellerMachinesCompanies)]|Não        |Lista de instituições pertencentes à marca |
+| Nome      | Tipo                                                                                    | Obrigatório | Definição                                     |
+|:--------- |:--------------------------------------------------------------------------------------- |:----------- | :-------------------------------------------- |
+| name      | string                                                                                  | Não         | Nome da Marca selecionada pelas Organizações. |
+| companies | [SharedAutomatedTellerMachinesCompanies](#schemaSharedAutomatedTellerMachinesCompanies) | Não         | Lista de instituições pertencentes à marca    |
 
 ## SharedAutomatedTellerMachinesCompanies
 <a id="schemaSharedAutomatedTellerMachinesCompanies"></a>
@@ -196,7 +196,7 @@
 
 |Nome                         |Tipo                                                                   |Obrigatório| Descrição                                                                                                                                                   |
 |:--------------------------- |:--------------------------------------------------------------------- |:--------- |:----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-|sharedAutomatedTellerMachines|[[SharedAutomatedTellerMachines](#schemaSharedAutomatedTellerMachines)]|Não        |                                                                                                                                                             |
+|sharedAutomatedTellerMachines|[SharedAutomatedTellerMachines](#schemaSharedAutomatedTellerMachines)  |Não        |                                                                                                                                                             |
 |name                         |string                                                                 |Não        | Nome da Instituição, pertencente à Marca.                                                                                                                   |
 |cnpjNumber                   |string                                                                 |Não        | Número completo do CNPJ da instituição.                                                                                                                     |
 |urlComplementaryList         |string                                                                 |Não        | URL de link para lista complementar com os nomes e CNPJs agrupados para o caso instituições ofertantes de produtos e serviços com as mesmas características.|

--- a/documentation/source/swagger/swagger_channels_apis.yaml
+++ b/documentation/source/swagger/swagger_channels_apis.yaml
@@ -1054,7 +1054,7 @@ components:
           type: string
           description: "Código IBGE do município"
           maxLength: 7
-          pattern: \d{7}|^NA$
+          pattern: ^\d{7}$
           example: '3515890'
         countrySubDivision:
           type: string
@@ -1677,7 +1677,7 @@ components:
           type: string
           description: "Código IBGE do município"
           maxLength: 7
-          pattern: \d{7}|^NA$
+          pattern: \d{7}
           example: '3515890'
         countrySubDivision:
           type: string

--- a/documentation/source/swagger/swagger_channels_apis.yaml
+++ b/documentation/source/swagger/swagger_channels_apis.yaml
@@ -767,7 +767,7 @@ components:
         relatedBranch:
           type: string
           maxLength: 4
-          pattern: ^\d{4}$|^NA$
+          pattern: ^\d{4}$
           description: Código da agência vinculada ao Posto de Atendimento - se aplicável
         openingDate:
           type: string
@@ -1521,13 +1521,13 @@ components:
         latitude:
           description: Informação da latitude referente a geolocalização informada.
           type: string
-          pattern: ^-?\d{1,2}\.\d{1,9}$|^NA$
+          pattern: ^-?\d{1,2}\.\d{1,9}$
           maxLength: 13
           example: '-90.8365180'
         longitude:
           description: Informação da longitude referente a geolocalização informada.
           type: string
-          pattern: ^-?\d{1,3}\.\d{1,8}$|^NA$
+          pattern: ^-?\d{1,3}\.\d{1,8}$
           maxLength: 13
           example: '-180.836519'
     Brand:


### PR DESCRIPTION
Correções na API de Canais de atendimento:
- Adição de "NA" nas expressões regulares para campos obrigatórios 
- Remoção do "NA" nas expressões regulares para campos opcionais e condicionais
- Atualização dos exemplos
- Remoção de colchetes nos links do SlateDocs