### PR TITLE
Remove indexer at CreditCards PN/PJ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Corrige os campos `minimumRate` e `maximumRate` de cartões de crédito PN e PJ para `minimum/rate` e `maximum/rate`;
 * Atualiza os dicionários com as correções acima;
 * Corrige tabela de códigos de resposta para chamadas com o método POST, onde estava sinalizado que poderia haver retorno com código 200 porém será sempre 201.
+* Corrige em `rates` em `interest/rates/applications/rate` para Cartão de Crédito PN e PJ para ficar de acordo com os respectivos dicionários.
 
 # v1.0.0-rc4
 [18/12/2020]

--- a/documentation/source/includes/partials_products_services_apis/_business_credit_cards.md.erb
+++ b/documentation/source/includes/partials_products_services_apis/_business_credit_cards.md.erb
@@ -102,36 +102,28 @@ req.send();
                     "applications": [
                       {
                         "interval": "1_FAIXA",
-                        "indexer": {
-                          "rate": "0.1500"
-                        },
+                        "rate": "0.1500",
                         "customers": {
                           "rate": "0.1500"
                         }
                       },
                       {
                         "interval": "2_FAIXA",
-                        "indexer": {
-                          "rate": "0.2000"
-                        },
+                        "rate": "0.2000",
                         "customers": {
                           "rate": "0.2500"
                         }
                       },
                       {
                         "interval": "3_FAIXA",
-                        "indexer": {
-                          "rate": "0.3500"
-                        },
+                        "rate": "0.3500",
                         "customers": {
                           "rate": "0.2500"
                         }
                       },
                       {
                         "interval": "4_FAIXA",
-                        "indexer": {
-                          "rate": "0.6800"
-                        },
+                        "rate": "0.6800",
                         "customers": {
                           "rate": "0.3500"
                         }

--- a/documentation/source/includes/partials_products_services_apis/_personal_credit_cards.md.erb
+++ b/documentation/source/includes/partials_products_services_apis/_personal_credit_cards.md.erb
@@ -103,36 +103,28 @@ req.send();
                     "applications": [
                       {
                         "interval": "1_FAIXA",
-                        "indexer": {
-                          "rate": "0.0987"
-                        },
+                        "rate": "0.0987",
                         "customers": {
                           "rate": "0.1500"
                         }
                       },
                       {
                         "interval": "2_FAIXA",
-                        "indexer": {
-                          "rate": "0.1600"
-                        },
+                        "rate": "0.1600",
                         "customers": {
                           "rate": "0.3500"
                         }
                       },
                       {
                         "interval": "3_FAIXA",
-                        "indexer": {
-                          "rate": "0.3600"
-                        },
+                        "rate": "0.3600",
                         "customers": {
                           "rate": "0.2000"
                         }
                       },
                       {
                         "interval": "4_FAIXA",
-                        "indexer": {
-                          "rate": "0.5890"
-                        },
+                        "rate": "0.5890",
                         "customers": {
                           "rate": "0.3000"
                         }

--- a/documentation/source/includes/partials_schemas/_common.md.erb
+++ b/documentation/source/includes/partials_schemas/_common.md.erb
@@ -345,9 +345,7 @@ Tipos de taxas referenciais ou indexadores, conforme Anexo 5: Taxa referencial o
   "applications": [
     {
       "interval": "string",
-      "indexer": {
-        "rate": "string"
-      },
+      "rate": "string",
       "customers": {
         "rate": "string"
       }
@@ -366,13 +364,33 @@ Tipos de taxas referenciais ou indexadores, conforme Anexo 5: Taxa referencial o
 |:--------------------- |:--------------------------------------------------------------|:------------|:--------------------------------------------------------------------------------------------------------------------- |
 | referentialRateIndexer| [ReferentialRateIndexer](#schemareferentialrateorindexer)     | Sim         | Tipos de taxas referenciais ou indexadores, conforme Anexo 5: Taxa referencial ou Indexador (Indx), do Documento 3040 |
 | rate                  | [RateString](#commonFieldRateString)                          | Sim         | Percentual que incide sobre a composição das taxas de juros remuneratórios.                                           |
-| applications          | [Application](#schemaApplication)                             | Sim         | Lista distribuição percentuais relativos à taxa de juros remuneratórios                                               |
+| applications          | [CreditCardApplication](#schemaCreditCardApplication)         | Sim         | Lista distribuição percentuais relativos à taxa de juros remuneratórios                                               |
 | minimum               | [Minimum](#schemaMinimumRateCredit)                           | Sim         | Percentual mínimo cobrado para a taxa do crédito rotativo no mês de referência.                                       |
 | maximum               | [Maximum](#schemaMaximumRateCredit)                           | Sim         | Percentual máximo cobrado para o pagamento parcelado do saldo devedor na fatura do mês de referência.                 |
 
-### Enum CreditCardInterestRateCode
+## CreditCardApplication
 
-<a id="schemaEnumCreditCardInterestRateCode"></a>
+<a id="schemaCreditCardApplication"></a>
+
+```json
+{
+  "interval": "string",
+  "rate": "string",
+  "customers": {
+    "rate": "string"
+  }
+}
+```
+
+|   Nome    | Tipo                                       | Obrigatório | Definição                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+|:--------- |:------------------------------------------ |:----------- |:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| interval  | [Enum PriceInterval](#schemaPriceInterval) | Sim         | Faixas para cobrança da taxa efetiva aplicada pela contratação do crédito, no intervalo informado: 1ª faixa, 2ª faixa, 3ª faixa e 4ª faixa. Segundo Normativa nº32 de 2020: 'Distribuição de frequência relativa dos valores de tarifas e taxas de juros cobrados dos clientes, de que trata o § 2º do art. 3º da Circular nº 4.015, de 2020, deve dar-se com base em quatro faixas de igual tamanho, com explicitação dos valores sobre a mediana e o percentual de clientes em cada uma dessas faixas. |
+| rate      | string                                     | Sim         | Percentual que corresponde a mediana (taxa efetiva) cobrada do cliente pela utilização do crédito rotativo, no intervalo informado. p.ex. '0,8700%'. A apuração pode acontecer com até 4 casas decimais. O preenchimento deve respeitar as 4 casas decimais, mesmo que venham preenchidas com zeros (representação de porcentagem p.ex: 0.15. Este valor representa 15%. O valor 1 representa 100%)                                                                                                      |
+| customers | [Customer](#schemaCustomer)                | Sim         | Percentual de clientes em cada faixa.                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+
+### Enum OtherCreditCode
+
+<a id="schemaEnumOtherCreditCode"></a>
 
 | Propriedade                 | Código               | Definição           |
 |:----------------------------|:---------------------|:------------------- |
@@ -380,9 +398,9 @@ Tipos de taxas referenciais ou indexadores, conforme Anexo 5: Taxa referencial o
 | code                        | PAGAMENTO_CONTA      | Pagamento de contas |
 | code                        | OUTROS               | Outros              |
 
-## CreditCardInterestRate
+## OtherCredit
 
-<a id="schemaCreditCardInterestRate"></a>
+<a id="schemaOtherCredit"></a>
 
 ```json
 {
@@ -393,7 +411,7 @@ Tipos de taxas referenciais ou indexadores, conforme Anexo 5: Taxa referencial o
 
 |     Nome       |  Tipo                                                                    | Obrigatório |    Definição                                                                                         |
 |:---------------|:-------------------------------------------------------------------------|:------------|:-----------------------------------------------------------------------------------------------------|
-| code           | [Enum CreditCardInterestRateCode](#schemaEnumCreditCardInterestRateCode) | Sim         | Lista de outras operações de crédito.                                                                |
+| code           | [Enum OtherCreditCode](#schemaEnumOtherCreditCode) | Sim         | Lista de outras operações de crédito.                                                                |
 | additionalInfo | string                                                                   | Não         | Campo Texto para descrever outras operações de crédito marcadas como 'OUTROS'.                       |
 
 ## CreditCardInstalmentRate
@@ -445,9 +463,7 @@ Tipos de taxas referenciais ou indexadores, conforme Anexo 5: Taxa referencial o
       "applications": [
         {
           "interval": "string",
-          "indexer": {
-            "rate": "string"
-          },
+          "rate": "string",
           "customers": {
             "rate": "string"
           }
@@ -497,7 +513,7 @@ Tipos de taxas referenciais ou indexadores, conforme Anexo 5: Taxa referencial o
 |:--------------- |:----------------------------------------------------------- |:------------ |:------------------------------------------------------------ |
 | rates           | [CreditCardRate](#schemaCreditCardRate)                     | Sim          | Lista da representação que traz o conjunto de informações necessárias para demonstrar a distribuição de frequências das taxas de juros remuneratórios para crédito rotativo |
 | instalmentRates | [CreditCardInstalmentRate](#schemaCreditCardInstalmentRate) | Sim          | Percentual que corresponde a taxa aplicada para pagamento parcelado do saldo devedor quando não realizado pagamento integral da fatura                                      |
-| otherCredits    | [CreditCardInterestRate](#schemaCreditCardInterestRate)     | Sim          | Lista de outras operações de crédito                                                                                                                                        |
+| otherCredits    | [OtherCredit](#schemaOtherCredit)                           | Sim          | Lista de outras operações de crédito                                                                                                                                        |
 
 ## CreditCardTermsConditions
 

--- a/documentation/source/includes/partials_schemas/_response_business_credit_cards.md.erb
+++ b/documentation/source/includes/partials_schemas/_response_business_credit_cards.md.erb
@@ -63,9 +63,7 @@
                     "applications": [
                       {
                         "interval": "string",
-                        "indexer": {
-                          "rate": "string"
-                        },
+                        "rate": "string",
                         "customers": {
                           "rate": "string"
                         }
@@ -205,9 +203,7 @@
                 "applications": [
                   {
                     "interval": "string",
-                    "indexer": {
-                      "rate": "string"
-                    },
+                    "rate": "string",
                     "customers": {
                       "rate": "string"
                     }
@@ -329,9 +325,7 @@
             "applications": [
               {
                 "interval": "string",
-                "indexer": {
-                  "rate": "string"
-                },
+                "rate": "string",
                 "customers": {
                   "rate": "string"
                 }
@@ -448,9 +442,7 @@
         "applications": [
           {
             "interval": "string",
-            "indexer": {
-              "rate": "string"
-            },
+            "rate": "string",
             "customers": {
               "rate": "string"
             }

--- a/documentation/source/includes/partials_schemas/_response_personal_credit_cards.md.erb
+++ b/documentation/source/includes/partials_schemas/_response_personal_credit_cards.md.erb
@@ -63,9 +63,7 @@
                     "applications": [
                       {
                         "interval": "string",
-                        "indexer": {
-                          "rate": "string"
-                        },
+                        "rate": "string",
                         "customers": {
                           "rate": "string"
                         }
@@ -100,6 +98,7 @@
                     "maximum":{
                       "rate": "string"
                     }
+                  }
                 ],
                 "otherCredits": [
                   {
@@ -204,9 +203,7 @@
                 "applications": [
                   {
                     "interval": "string",
-                    "indexer": {
-                      "rate": "string"
-                    },
+                    "rate": "string",
                     "customers": {
                       "rate": "string"
                     }
@@ -328,9 +325,7 @@
             "applications": [
               {
                 "interval": "string",
-                "indexer": {
-                  "rate": "string"
-                },
+                "rate": "string",
                 "customers": {
                   "rate": "string"
                 }
@@ -447,9 +442,7 @@
         "applications": [
           {
             "interval": "string",
-            "indexer": {
-              "rate": "string"
-            },
+            "rate": "string",
             "customers": {
               "rate": "string"
             }

--- a/documentation/source/swagger/swagger_products_services_apis.yaml
+++ b/documentation/source/swagger/swagger_products_services_apis.yaml
@@ -1329,7 +1329,7 @@ components:
         rates:
           type: array
           items:
-            $ref: '#/components/schemas/InterestRate'
+            $ref: '#/components/schemas/CreditCardRate'
           minItems: 1
           description: Lista da representação que traz o conjunto de informações necessárias para demonstrar a distribuição de frequências das taxas de juros remuneratórios para crédito rotativo
         instalmentRates:
@@ -1342,10 +1342,68 @@ components:
           type: array
           description: Lista de outras operações de crédito
           items:
-            $ref:  "#/components/schemas/CreditCardInterestRate"
+            $ref:  "#/components/schemas/OtherCredit"
           minItems: 1
           maxItems: 3
-    CreditCardInterestRate:
+    CreditCardRate:
+      type: object
+      required:
+        - referentialRateIndexer
+        - rate
+        - applications
+        - minimumRate
+        - maximumRate
+      properties:
+        referentialRateIndexer:
+          $ref: '#/components/schemas/ReferentialRateIndexer'
+        rate:
+          type: string
+          description: |
+            Percentual que incide sobre a composição das taxas de juros remuneratórios. (representa uma porcentagem Ex: 0.15 (O valor ao lado representa 15%. O valor '1 'representa 100%). A apuração pode acontecer com até 4 casas decimais. O preenchimento deve respeitar as 4 casas decimais, mesmo que venham preenchidas com zeros (representação de porcentagem p.ex: 0.1500. Este valor representa 15%. O valor 1 representa 100%)
+          pattern: '(^[0-9](\.[0-9]{2})|NA)$'
+          example: '0.15'
+        applications:
+          type: array
+          description: Lista distribuição percentuais relativos à taxa de juros remuneratórios
+          items:
+            $ref: "#/components/schemas/CreditCardApplication"
+          minItems: 4
+          maxItems: 4
+        minimum:
+          type: object
+          properties:
+            rate:
+              type: string
+              pattern: '(^[0-9](\.[0-9]{4})$|^NA$)'
+              description: 'Percentual mínimo cobrado (taxa efetiva) no mês de referência, para o Financiamento contratado  A apuração pode acontecer com até 4 casas decimais. O preenchimento deve respeitar as 4 casas decimais, mesmo que venham preenchidas com zeros (representação de porcentagem p.ex: 0.1500. Este valor representa 15%. O valor 1 representa 100%)'
+              example: '0.0456'
+        maximum:
+          type: object
+          properties:
+            rate:
+              type: string
+              pattern: '(^[0-9](\.[0-9]{4})$|^NA$)'
+              description: 'Percentual máximo cobrado (taxa efetiva) no mês de referência, para o Financiamento contratado  A apuração pode acontecer com até 4 casas decimais. O preenchimento deve respeitar as 4 casas decimais, mesmo que venham preenchidas com zeros (representação de porcentagem p.ex: 0.1500. Este valor representa 15%. O valor 1 representa 100%)'
+              example: '0.6865'
+    CreditCardApplication:
+      type: object
+      properties:
+        interval:
+          $ref: '#/components/schemas/ApplicationIntervals'
+        rate:
+          type: string
+          pattern: '(^[0-9](\.[0-9]{4})$|^NA$)'
+          maxLength: 6
+          description: |
+            Percentual que corresponde a mediana (taxa efetiva) cobrada do cliente pela utilização do crédito rotativo, no intervalo informado. 
+          example: '0.8700'
+        customers:
+          $ref: '#/components/schemas/Customer'
+      required:
+        - interval
+        - indexer
+        - customers
+    OtherCredit:
       type: object
       required:
         - code


### PR DESCRIPTION
Corrige rate em Cartão de Crédito PN e PJ para ficar conforme o dicionário 